### PR TITLE
Fix counpons

### DIFF
--- a/src/components/Dashboard/DashboardPages/DashMessages.js
+++ b/src/components/Dashboard/DashboardPages/DashMessages.js
@@ -170,8 +170,8 @@ export function DashMessages({ connection }) {
   return (
     <>
       {/* Header */}
-      <div className="flex justify-between items-center px-4 py-2 border-b">
-        <h2 className="text-2xl font-semibold">{connection.name}</h2>
+      <div className="flex justify-end items-center px-4 py-2 border-b">
+       
         <div className="space-x-2">
           <button
             onClick={() => setDatesModalOpen(true)}


### PR DESCRIPTION
First, we consolidated everything into a single dates array on each conversation instead of separate invites. As soon as an invite is accepted (currently we auto-accept our own invites until the chat UI is hooked up), a new object with status: "accepted", a timestamp, location, and a two-slot photos map is added to conversations/{conversationId}.dates. Each slot tracks { uploaded: boolean, url: string } for the two participants. On the coupons page you now have two “Date” dropdowns that list all accepted dates you’re part of (you can switch freely between them) and two upload boxes: your photo goes to Cloud Storage under datePictures, and only the download URL + uploaded:true flag is written back to Firestore. Once you submit, the slot shows “Submitted ” and your picture stays visible, while your partner’s slot shows “Waiting for partner.”

One thing I’d recommend for next up is optimizing how we load conversations: right now we query every convo where userIds contains you, then flatten and filter dates. In a larger scale app, we should have maybe an array of coversations ID for every user. We only ever listen to the conversations you’re actually in, rather than scanning the entire conversations collection. That change will improve performance and reduce unnecessary reads.